### PR TITLE
LIBBCM-119 Update documentation and docker setting

### DIFF
--- a/BCM-README.md
+++ b/BCM-README.md
@@ -3,6 +3,13 @@
 ### Developing for Broadcast Avalon using Docker
 
 1. Checkout [avalon](https://github.com/umd-lib/avalon) next to the avalon-docker directory.
+    In avalon, change the config/setting.yml redis settings to:
+
+    ```
+    redis:
+      host: redis 
+      port: 6379
+    ```
 
 2. Copy config files from avalon-docker to avalon:
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -22,6 +22,8 @@ services:
       - "5432:5432"
   fedora:
     image: avalonmediasystem/fedora:4.7.x
+    environment:
+      - JAVA_OPTIONS=-Dfcrepo.modeshape.configuration=classpath:/config/file-simple/repository.json
     build: 
       context: ./fedora
       args:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - "5432:5432"
   fedora:
     image: avalonmediasystem/fedora:4.7.5
+    environment:
+      - JAVA_OPTIONS=-Dfcrepo.modeshape.configuration="classpath:/config/file-simple/repository.json" 
     build: 
       context: ./fedora
       args:


### PR DESCRIPTION
Adds a small JAVA_OPTIONS for Fedora and updates the BCM-README.md for
updating redis settings in Avalon