### PR TITLE
LIBAVALON-65. Store all Avalon docker images in UMD Docker.

### DIFF
--- a/AP-README.md
+++ b/AP-README.md
@@ -4,7 +4,37 @@ Instructions to build and deploy Avalon Pilot docker images to the UMD Nexus Doc
 
 ## Build and push images to UMD Nexus Docker Registry
 ```
-docker-compose -f avalon-pilot-compose.yml build db fedora avalon
-docker-compose -f avalon-pilot-compose.yml push db fedora avalon
+docker-compose -f avalon-pilot-compose.yml build db avalon
+docker-compose -f avalon-pilot-compose.yml push db avalon
 ```
-Note: Currently, db, fedora, and avalon are the only customized images. If other images are customized, those needs to be included in the above commands to be built and pushed to the UMD Nexus Docker Registry.
+Note: Currently, db and avalon are the only customized images. If other images are customized, those needs to be included in the above commands to be built and pushed to the UMD Nexus Docker Registry.
+
+
+## Pull and push images to UMD Nexus Docker Registry
+For images that does not need any customization, we can pull (from dockerhub), tag, and push (to UMD Docker). The avalon docker images for supporting services does seem to follow a consistent pattern for versioning, so we can tag them with the Avalon application version they are compatible with.
+
+```
+docker pull avalonmediasystem/<service>:<tag>
+docker tag avalonmediasystem/<service>:<tag> docker.lib.umd.edu/avalonmediasystem/<service>:<avalon-app-version>
+docker push docker.lib.umd.edu/avalonmediasystem/<service>:<avalon-app-version>
+```
+
+**Note:** After pulling the image, we need to verify that the images are compatible with the Avalon application before tagging and pushing.
+
+Example: Pulling the current avalonmediasystem images and tagging them as 6.4.2 compatible images.
+```
+docker pull avalonmediasystem/fedora:4.7.5
+docker pull avalonmediasystem/solr:latest
+docker pull avalonmediasystem/matterhorn
+docker pull avalonmediasystem/nginx
+
+docker tag avalonmediasystem/fedora:4.7.5 docker.lib.umd.edu/avalonmediasystem/fedora:6.4.2
+docker tag avalonmediasystem/solr:latest docker.lib.umd.edu/avalonmediasystem/solr:6.4.2
+docker tag avalonmediasystem/matterhorn docker.lib.umd.edu/avalonmediasystem/matterhorn:6.4.2
+docker tag avalonmediasystem/nginx docker.lib.umd.edu/avalonmediasystem/nginx:6.4.2
+
+docker push docker.lib.umd.edu/avalonmediasystem/fedora:6.4.2
+docker push docker.lib.umd.edu/avalonmediasystem/solr:6.4.2
+docker push docker.lib.umd.edu/avalonmediasystem/matterhorn:6.4.2
+docker push docker.lib.umd.edu/avalonmediasystem/nginx:6.4.2
+```

--- a/avalon-pilot-compose.yml
+++ b/avalon-pilot-compose.yml
@@ -3,16 +3,16 @@ version: "3.6"
 
 services:
   db:
-    image: docker.lib.umd.edu/avalonmediasystem/db:fedora4-ap-0
+    image: docker.lib.umd.edu/avalonmediasystem/db:6.4.2
     build: ./db
   fedora:
-    image: docker.lib.umd.edu/avalonmediasystem/fedora:4.7.5-ap-0
-    build: 
+    image: docker.lib.umd.edu/avalonmediasystem/fedora:6.4.2
+    build:
       context: ./fedora
       args:
         - FEDORA_VERSION=4.7.5
   solr:
-    image: avalonmediasystem/solr:latest
+    image: docker.lib.umd.edu/avalonmediasystem/solr:6.4.2
     build: 
       context: ./solr
       args:
@@ -25,7 +25,7 @@ services:
         - MATTERHORN_VER=1.4
         - MATTERHORN_BRANCH=1.4.x
   hls:
-    image: avalonmediasystem/nginx
+    image: avalonmediasystem/nginx:6.4.2
     build:
       context: ./nginx
   redis:
@@ -35,5 +35,5 @@ services:
     build:
       context: ./avalon
       args:
-        - AVALON_REPO=https://github.com/umd-lib/avalon.git
-        - AVALON_BRANCH=ap-master
+        - AVALON_REPO
+        - AVALON_BRANCH


### PR DESCRIPTION
https://issues.umd.edu/browse/LIBAVALON-65