### PR TITLE
LIBAVALON-65. Revert fedora to custom version.

### DIFF
--- a/AP-README.md
+++ b/AP-README.md
@@ -4,10 +4,10 @@ Instructions to build and deploy Avalon Pilot docker images to the UMD Nexus Doc
 
 ## Build and push images to UMD Nexus Docker Registry
 ```
-docker-compose -f avalon-pilot-compose.yml build db avalon
-docker-compose -f avalon-pilot-compose.yml push db avalon
+docker-compose -f avalon-pilot-compose.yml build db fedora avalon
+docker-compose -f avalon-pilot-compose.yml push db fedora avalon
 ```
-Note: Currently, db and avalon are the only customized images. If other images are customized, those needs to be included in the above commands to be built and pushed to the UMD Nexus Docker Registry.
+Note: Currently, db, fedora, and avalon are the only customized images. If other images are customized, those needs to be included in the above commands to be built and pushed to the UMD Nexus Docker Registry.
 
 
 ## Pull and push images to UMD Nexus Docker Registry
@@ -23,17 +23,14 @@ docker push docker.lib.umd.edu/avalonmediasystem/<service>:<avalon-app-version>
 
 Example: Pulling the current avalonmediasystem images and tagging them as 6.4.2 compatible images.
 ```
-docker pull avalonmediasystem/fedora:4.7.5
 docker pull avalonmediasystem/solr:latest
 docker pull avalonmediasystem/matterhorn
 docker pull avalonmediasystem/nginx
 
-docker tag avalonmediasystem/fedora:4.7.5 docker.lib.umd.edu/avalonmediasystem/fedora:6.4.2
 docker tag avalonmediasystem/solr:latest docker.lib.umd.edu/avalonmediasystem/solr:6.4.2
 docker tag avalonmediasystem/matterhorn docker.lib.umd.edu/avalonmediasystem/matterhorn:6.4.2
 docker tag avalonmediasystem/nginx docker.lib.umd.edu/avalonmediasystem/nginx:6.4.2
 
-docker push docker.lib.umd.edu/avalonmediasystem/fedora:6.4.2
 docker push docker.lib.umd.edu/avalonmediasystem/solr:6.4.2
 docker push docker.lib.umd.edu/avalonmediasystem/matterhorn:6.4.2
 docker push docker.lib.umd.edu/avalonmediasystem/nginx:6.4.2

--- a/avalon-pilot-compose.yml
+++ b/avalon-pilot-compose.yml
@@ -6,7 +6,7 @@ services:
     image: docker.lib.umd.edu/avalonmediasystem/db:6.4.2
     build: ./db
   fedora:
-    image: docker.lib.umd.edu/avalonmediasystem/fedora:6.4.2
+    image: docker.lib.umd.edu/avalonmediasystem/fedora:6.4.2-ap-0
     build:
       context: ./fedora
       args:


### PR DESCRIPTION
Avalon provided fedora 4.7.5 version fails due to missing `fcrepo.modeshape.configuration`

https://issues.umd.edu/browse/LIBAVALON-65