### PR TITLE
LIBAVALON-69. Fix media streaming error.

### DIFF
--- a/avalon-pilot-compose.yml
+++ b/avalon-pilot-compose.yml
@@ -25,7 +25,7 @@ services:
         - MATTERHORN_VER=1.4
         - MATTERHORN_BRANCH=1.4.x
   hls:
-    image: avalonmediasystem/nginx:6.4.2
+    image: docker.lib.umd.edu/avalonmediasystem/nginx:6.4.2-ap-0
     build:
       context: ./nginx
   redis:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -62,7 +62,7 @@ http {
     
     location /thumb/ {
       alias /data/;
-      vod thumb;
+      vod none;
     }
     
     location ~ ^/avalon/(?<stream>.+)/(?<resource>.+\.(?:m3u8|ts)) {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -43,6 +43,11 @@ http {
     vod_last_modified_types *;
     vod_metadata_cache metadata_cache 512m;
     vod_response_cache response_cache 128m;
+    set $b_url "$host";
+    if ($http_host != "") {
+      set $b_url "//$http_host";
+    }
+    vod_segments_base_url "$b_url"; 
     gzip on;
     gzip_types application/vnd.apple.mpegurl;
     open_file_cache          max=1000 inactive=5m;


### PR DESCRIPTION
Use scheme less URLs to avoid mixed content errors.

https://issues.umd.edu/browse/LIBAVALON-69