### PR TITLE
LIBAVALON-538. Add Docker images for Fedora 4 → 6 migration K8s jobs.

### DIFF
--- a/fedora/Dockerfile.fcrepo-migrate-4-to-6
+++ b/fedora/Dockerfile.fcrepo-migrate-4-to-6
@@ -1,0 +1,46 @@
+# Fedora Migration Image (F4 → F5 → F6)
+#
+# Converts a Fedora 4 export (produced by fcrepo4-export) into a Fedora 6
+# OCFL store via the two-step fcrepo-upgrade-utils process:
+#   F4 export  →  F5 intermediate  →  F6 OCFL
+#
+# Usage (Docker — standalone):
+#   docker run --rm \
+#     -e BASE_URI=http://fedora:8080/fcrepo/rest \
+#     -v /path/to/data:/data \
+#     docker.lib.umd.edu/fcrepo-migrate:latest
+#
+# Note: The migrate job does not connect to Fedora directly — BASE_URI is only
+#       embedded into the OCFL metadata as the resource identifier. No network
+#       attachment is required for the migration step.
+#
+# Volume layout expected under /data:
+#   /data/fcrepo4_export/   — input: produced by fcrepo4-export image
+#   /data/fcrepo5_export/   — intermediate (created by this image)
+#   /data/fcrepo6_export/   — output OCFL store (created by this image)
+#   /data/upgrade_5_*.log   — step 1 log
+#   /data/upgrade_6_*.log   — step 2 log
+#
+# Usage (K8s Job): see ../k8s/fcrepo-migrate-job.yaml
+
+FROM eclipse-temurin:21-jre-jammy
+
+LABEL maintainer="UMD Libraries <lib-systems@umd.edu>"
+LABEL description="Migrates Fedora 4 export to Fedora 6 OCFL format"
+
+ARG UPGRADE_UTILS_VERSION=6.3.0-AVALON
+ARG UPGRADE_UTILS_JAR=fcrepo-upgrade-utils-${UPGRADE_UTILS_VERSION}.jar
+ARG UPGRADE_UTILS_URL=https://github.com/avalonmediasystem/fcrepo-upgrade-utils/releases/download/${UPGRADE_UTILS_VERSION}/${UPGRADE_UTILS_JAR}
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL -o /opt/fcrepo-upgrade-utils.jar "${UPGRADE_UTILS_URL}"
+
+COPY fcrepo-migrate-4-to-6.sh /usr/local/bin/migrate.sh
+RUN chmod +x /usr/local/bin/migrate.sh
+
+VOLUME ["/data"]
+
+ENTRYPOINT ["/usr/local/bin/migrate.sh"]

--- a/fedora/Dockerfile.fcrepo4-export
+++ b/fedora/Dockerfile.fcrepo4-export
@@ -1,0 +1,56 @@
+# Fedora 4 Export Image
+#
+# Exports all content from a running Fedora 4 instance using the
+# fcrepo-import-export tool. Output is written to a mounted volume.
+#
+# Usage (Docker — standalone):
+#   docker run --rm \
+#     -e FEDORA_URL=http://fedora:8080/fedora/rest \
+#     -e FEDORA_USER=fedoraAdmin \
+#     -e FEDORA_PASSWORD=fedoraAdmin \
+#     -v /path/to/output:/data \
+#     docker.lib.umd.edu/fcrepo4-export:latest
+#
+# Usage (Docker — attached to existing docker-compose stack):
+#   docker run --rm \
+#     --network avalon_internal \
+#     -e FEDORA_URL=http://fedora:8080/fedora/rest \
+#     -e FEDORA_USER=fedoraAdmin \
+#     -e FEDORA_PASSWORD=fedoraAdmin \
+#     -v /path/to/output:/data \
+#     docker.lib.umd.edu/fcrepo4-export:latest
+#
+# Note: Fedora 4 REST path is /fedora/rest. Fedora 6 uses /fcrepo/rest.
+#
+# Note: The compose project network is named <project>_internal.
+#       Default project name is the directory name (avalon_internal).
+#       Override with: docker compose -p myproject ... or COMPOSE_PROJECT_NAME env var.
+#
+# Usage (K8s Job): see ../k8s/fcrepo4-export-job.yaml
+#
+# Volume:
+#   /data  — output directory; export lands in /data/fcrepo4_export/
+#            logs land in /data/export_<timestamp>.log
+#            any remaining_<timestamp>.log file triggers automatic resume
+
+FROM eclipse-temurin:21-jre-jammy
+
+LABEL maintainer="UMD Libraries <lib-systems@umd.edu>"
+LABEL description="Exports Fedora 4 content via fcrepo-import-export"
+
+ARG IMPORT_EXPORT_VERSION=1.2.0
+ARG IMPORT_EXPORT_JAR=fcrepo-import-export-${IMPORT_EXPORT_VERSION}.jar
+ARG IMPORT_EXPORT_URL=https://github.com/fcrepo-exts/fcrepo-import-export/releases/download/fcrepo-import-export-${IMPORT_EXPORT_VERSION}/${IMPORT_EXPORT_JAR}
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL -o /opt/fcrepo-import-export.jar "${IMPORT_EXPORT_URL}"
+
+COPY fcrepo4-export.sh /usr/local/bin/export.sh
+RUN chmod +x /usr/local/bin/export.sh
+
+VOLUME ["/data"]
+
+ENTRYPOINT ["/usr/local/bin/export.sh"]

--- a/fedora/FCREPO4-MIGRATION.md
+++ b/fedora/FCREPO4-MIGRATION.md
@@ -1,0 +1,267 @@
+# Fedora 4 → 6 Data Migration
+
+This directory contains two Docker images for migrating Avalon's Fedora 4
+repository to the Fedora 6 OCFL storage format. The migration is a two-phase
+process: first export the live Fedora 4 data, then convert that export to the
+Fedora 6 OCFL layout.
+
+```
+Fedora 4 (live)
+       │
+       │  fcrepo4-export image
+       ▼
+ /data/fcrepo4_export/
+       │
+       │  fcrepo-migrate image  (step 1: F4 → F5)
+       ▼
+ /data/fcrepo5_export/
+       │
+       │  fcrepo-migrate image  (step 2: F5 → F6)
+       ▼
+ /data/fcrepo6_export/   ← load into Fedora 6
+```
+
+Both images use `eclipse-temurin:21-jre-jammy` as the base and share a single
+`/data` volume so that each phase's output is automatically available as the
+next phase's input.
+
+---
+
+## Images
+
+| Image | Dockerfile | Purpose |
+|-------|-----------|---------|
+| `docker.lib.umd.edu/fcrepo4-export:latest` | `Dockerfile.fcrepo4-export` | Export Fedora 4 content via [fcrepo-import-export 1.2.0](https://github.com/fcrepo-exts/fcrepo-import-export/releases/tag/fcrepo-import-export-1.2.0) |
+| `docker.lib.umd.edu/fcrepo-migrate:latest` | `Dockerfile.fcrepo-migrate-4-to-6` | Convert the export to Fedora 6 OCFL via [fcrepo-upgrade-utils 6.3.0-AVALON](https://github.com/avalonmediasystem/fcrepo-upgrade-utils/releases/tag/6.3.0-AVALON) |
+
+### Building
+
+```bash
+# From the repo root
+docker build -f fedora/Dockerfile.fcrepo4-export \
+  -t docker.lib.umd.edu/fcrepo4-export:latest fedora/
+
+docker build -f fedora/Dockerfile.fcrepo-migrate-4-to-6 \
+  -t docker.lib.umd.edu/fcrepo-migrate:latest fedora/
+```
+
+Building for K8s deployment
+
+```bash
+# From the repo root
+docker buildx build --no-cache --builder kube --platform linux/amd64 \
+    --push -f fedora/Dockerfile.fcrepo4-export \
+    -t docker.lib.umd.edu/fcrepo4-export:avalon-$GIT_TAG fedora/
+
+docker buildx build --no-cache --builder kube --platform linux/amd64 \
+    --push -f fedora/Dockerfile.fcrepo-migrate-4-to-6 \
+    -t docker.lib.umd.edu/fcrepo-migrate:avalon-$GIT_TAG fedora/
+```
+
+---
+
+## Phase 1: Export Fedora 4 Content
+
+The `fcrepo4-export` image connects to a **running** Fedora 4 instance and
+dumps all RDF resources and binaries to `/data/fcrepo4_export/`.
+
+> **Note:** Fedora 4's REST path is `/fedora/rest`; Fedora 6 uses `/fcrepo/rest`.
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FEDORA_URL` | `http://fedora:8080/fedora/rest` | Fedora 4 REST API base URL |
+| `FEDORA_USER` | `fedoraAdmin` | Fedora admin username |
+| `FEDORA_PASSWORD` | `fedoraAdmin` | Fedora admin password |
+| `EXPORT_DIR` | `/data/fcrepo4_export` | Directory to write export output |
+| `DATA_DIR` | `/data` | Root of the mounted volume (logs are written here) |
+
+### Volume layout produced
+
+```
+/data/
+  fcrepo4_export/          ← RDF and binary export output
+  export_<timestamp>.log   ← full export log
+  remaining_<timestamp>.log  ← written only if export was interrupted
+```
+
+### Running against a docker-compose stack
+
+```bash
+docker run --rm \
+  --network avalon_internal \
+  -e FEDORA_URL=http://fedora:8080/fedora/rest \
+  -e FEDORA_USER=fedoraAdmin \
+  -e FEDORA_PASSWORD=fedoraAdmin \
+  -v /path/to/data:/data \
+  docker.lib.umd.edu/fcrepo4-export:latest
+```
+
+The compose project network is named `<project>_internal`. The default project
+name is the containing directory (e.g. `avalon_internal`). Override with
+`-p myproject` or the `COMPOSE_PROJECT_NAME` environment variable.
+
+### Running standalone (Fedora 4 accessible on host)
+
+```bash
+docker run --rm \
+  -e FEDORA_URL=http://host.docker.internal:8080/fedora/rest \
+  -e FEDORA_USER=fedoraAdmin \
+  -e FEDORA_PASSWORD=fedoraAdmin \
+  -v /path/to/data:/data \
+  docker.lib.umd.edu/fcrepo4-export:latest
+```
+
+### Resume after interruption
+
+If the export is interrupted, a `remaining_<timestamp>.log` file is written to
+`/data`. Re-run the container with the **same volume** and the script will
+automatically detect the remaining file and resume:
+
+```bash
+# Same command as the original run — no extra flags needed
+docker run --rm \
+  --network avalon_internal \
+  -e FEDORA_URL=http://fedora:8080/fedora/rest \
+  -e FEDORA_USER=fedoraAdmin \
+  -e FEDORA_PASSWORD=fedoraAdmin \
+  -v /path/to/data:/data \
+  docker.lib.umd.edu/fcrepo4-export:latest
+```
+
+---
+
+## Phase 2: Migrate Export to Fedora 6 OCFL
+
+The `fcrepo-migrate` image runs entirely offline against the `/data` volume —
+it **does not connect to any Fedora instance**. `BASE_URI` is only embedded into
+the OCFL metadata as the canonical resource identifier.
+
+The migration is a two-step process:
+
+1. **F4 → F5** — converts Fedora 4.7.5 export format to Fedora 5 intermediate format
+2. **F5 → F6** — converts the F5 intermediate to a Fedora 6 OCFL repository
+
+If a step has already completed (detected via a done-marker file in `/data`),
+it is skipped on re-run.
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BASE_URI` | `http://fedora:8080/fcrepo/rest` | Fedora 6 REST base URI embedded in OCFL metadata |
+| `DATA_DIR` | `/data` | Root of the mounted volume |
+| `INPUT_DIR` | `/data/fcrepo4_export` | Fedora 4 export input (from Phase 1) |
+| `F5_DIR` | `/data/fcrepo5_export` | F5 intermediate output directory |
+| `F6_DIR` | `/data/fcrepo6_export` | F6 OCFL output directory |
+
+### Volume layout consumed/produced
+
+```
+/data/
+  fcrepo4_export/            ← input (from Phase 1)
+  fcrepo5_export/            ← F5 intermediate (created by step 1)
+  fcrepo6_export/            ← F6 OCFL store   (created by step 2)
+  upgrade_5_<timestamp>.log  ← step 1 log
+  upgrade_6_<timestamp>.log  ← step 2 log
+  .f4_to_f5_complete         ← done-marker for step 1
+  .f5_to_f6_complete         ← done-marker for step 2
+  remaining_f4_to_f5_*.log   ← written if step 1 was interrupted
+  remaining_f5_to_f6_*.log   ← written if step 2 was interrupted
+```
+
+### Running the migration
+
+The `/data` volume must contain the `fcrepo4_export/` directory produced by
+Phase 1 before running this image.
+
+```bash
+docker run --rm \
+  -e BASE_URI=http://fedora:8080/fcrepo/rest \
+  -v /path/to/data:/data \
+  docker.lib.umd.edu/fcrepo-migrate:latest
+```
+
+### Resume after interruption
+
+Re-run the container with the same volume. The script detects
+`remaining_f4_to_f5_*.log` or `remaining_f5_to_f6_*.log` files and resumes the
+interrupted step. Completed steps (marked by `.f4_to_f5_complete` /
+`.f5_to_f6_complete`) are skipped automatically.
+
+```bash
+# Same command as the original run — no extra flags needed
+docker run --rm \
+  -e BASE_URI=http://fedora:8080/fcrepo/rest \
+  -v /path/to/data:/data \
+  docker.lib.umd.edu/fcrepo-migrate:latest
+```
+
+---
+
+## Kubernetes Jobs
+
+K8s Job manifests are maintained in the `k8s-avalon` repository:
+
+- `k8s/fcrepo4-export-job.yaml` — runs Phase 1 as a K8s Job
+- `k8s/fcrepo-migrate-job.yaml` — runs Phase 2 as a K8s Job
+
+---
+
+## Full Migration Walkthrough
+
+### 1. Provision a shared data volume
+
+The same persistent volume must be mounted by both jobs.
+
+```bash
+mkdir -p /mnt/fcrepo-migration
+```
+
+### 2. Run the export (Phase 1)
+
+```bash
+docker run --rm \
+  --network avalon_internal \
+  -e FEDORA_URL=http://fedora:8080/fedora/rest \
+  -e FEDORA_USER=fedoraAdmin \
+  -e FEDORA_PASSWORD=fedoraAdmin \
+  -v /mnt/fcrepo-migration:/data \
+  docker.lib.umd.edu/fcrepo4-export:latest
+```
+
+On success the log ends with:
+
+```
+[...] Export completed successfully. Output: /data/fcrepo4_export
+```
+
+### 3. Run the migration (Phase 2)
+
+```bash
+docker run --rm \
+  -e BASE_URI=http://fedora:8080/fcrepo/rest \
+  -v /mnt/fcrepo-migration:/data \
+  docker.lib.umd.edu/fcrepo-migrate:latest
+```
+
+On success the log ends with:
+
+```
+[...] Migration complete. Fedora 6 OCFL data is in: /data/fcrepo6_export
+[...] Next step: sync /data/fcrepo6_export/data/ocfl-root to your Fedora 6 storage.
+```
+
+### 4. Load the OCFL store into Fedora 6
+
+Copy or sync `/mnt/fcrepo-migration/fcrepo6_export/data/ocfl-root` to the
+storage location configured for your Fedora 6 instance, then restart Fedora 6.
+
+---
+
+## Reference
+
+- [Avalon Fedora Migration Guide](https://samvera.atlassian.net/wiki/spaces/AVALON/pages/2808086529)
+- [fcrepo-import-export](https://github.com/fcrepo-exts/fcrepo-import-export)
+- [fcrepo-upgrade-utils (Avalon fork)](https://github.com/avalonmediasystem/fcrepo-upgrade-utils)

--- a/fedora/fcrepo-migrate-4-to-6.sh
+++ b/fedora/fcrepo-migrate-4-to-6.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Migrate a Fedora 4 export to Fedora 6 OCFL format.
+# Runs two upgrade passes: F4 → F5 (intermediate), then F5 → F6.
+#
+# Environment variables:
+#   BASE_URI     Fedora REST base URI used in F6 OCFL metadata
+#                (default: http://fedora:8080/fedora/rest)
+#   DATA_DIR     Root of the data volume              (default: /data)
+#   INPUT_DIR    F4 export directory                  (default: $DATA_DIR/fcrepo4_export)
+#   F5_DIR       F5 intermediate output directory     (default: $DATA_DIR/fcrepo5_export)
+#   F6_DIR       F6 OCFL output directory             (default: $DATA_DIR/fcrepo6_export)
+#
+# Resume:
+#   If a step fails mid-way, a remaining_<timestamp>.log file is written.
+#   Re-run the container with the same /data volume; the script will
+#   detect the remaining file for whichever step failed and resume it.
+
+set -euo pipefail
+
+BASE_URI="${BASE_URI:-http://fedora:8080/fcrepo/rest}"
+DATA_DIR="${DATA_DIR:-/data}"
+INPUT_DIR="${INPUT_DIR:-${DATA_DIR}/fcrepo4_export}"
+F5_DIR="${F5_DIR:-${DATA_DIR}/fcrepo5_export}"
+F6_DIR="${F6_DIR:-${DATA_DIR}/fcrepo6_export}"
+
+TIMESTAMP=$(date +%Y%m%dT%H%M%S)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+log() { echo "[$(date -Iseconds)] $*"; }
+
+# Check if an output directory is non-empty (primary completion indicator).
+# fcrepo-upgrade-utils exits 0 on success but prints no "complete" banner.
+output_has_content() {
+  local dir="$1"
+  [[ -d "${dir}" ]] && [[ -n "$(ls -A "${dir}" 2>/dev/null)" ]]
+}
+
+find_remaining() {
+  local prefix="$1"
+  ls -t "${DATA_DIR}"/remaining_${prefix}*.log 2>/dev/null | head -1 || true
+}
+
+# Run java and capture its exit code even through the tee pipeline.
+run_java() {
+  local log_file="$1"
+  shift
+  java "$@" 2>&1 | tee "${log_file}"
+  return "${PIPESTATUS[0]}"
+}
+
+# ── Validate input ────────────────────────────────────────────────────────────
+
+if [[ ! -d "${INPUT_DIR}" ]]; then
+  log "ERROR: Input directory not found: ${INPUT_DIR}" >&2
+  log "       Mount the fcrepo4-export output volume at ${DATA_DIR}" >&2
+  exit 1
+fi
+
+mkdir -p "${F5_DIR}" "${F6_DIR}"
+
+log "Starting Fedora 4 → 6 migration"
+log "  INPUT_DIR : ${INPUT_DIR}"
+log "  F5_DIR    : ${F5_DIR}"
+log "  F6_DIR    : ${F6_DIR}"
+log "  BASE_URI  : ${BASE_URI}"
+
+# ── Step 1: F4 → F5 ──────────────────────────────────────────────────────────
+
+F5_LOG="${DATA_DIR}/upgrade_5_${TIMESTAMP}.log"
+F5_DONE_MARKER="${DATA_DIR}/.f4_to_f5_complete"
+
+if [[ -f "${F5_DONE_MARKER}" ]]; then
+  log "Step 1 (F4→F5) already completed — skipping."
+else
+  RESUME_ARGS=()
+  REMAINING=$(find_remaining "f4_to_f5")
+  if [[ -n "${REMAINING}" ]]; then
+    log "Step 1: Resuming from: ${REMAINING}"
+    RESUME_ARGS=(--resource-info-file "${REMAINING}")
+  else
+    log "Step 1: Migrating Fedora 4 → Fedora 5..."
+  fi
+
+  run_java "${F5_LOG}" \
+    -jar /opt/fcrepo-upgrade-utils.jar \
+    --input-dir "${INPUT_DIR}" \
+    --output-dir "${F5_DIR}" \
+    --source-version 4.7.5 \
+    --target-version 5+ \
+    "${RESUME_ARGS[@]}"
+  JAVA_EXIT=$?
+
+  if [[ "${JAVA_EXIT}" -eq 0 ]] && output_has_content "${F5_DIR}"; then
+    log "Step 1 (F4→F5) completed successfully."
+    touch "${F5_DONE_MARKER}"
+  else
+    REMAINING_NEW=$(find_remaining "")
+    if [[ -n "${REMAINING_NEW}" ]]; then
+      log "ERROR: Step 1 did not finish. Resume file: ${REMAINING_NEW}" >&2
+      # Rename so we can identify it belongs to step 1 on next run
+      mv "${REMAINING_NEW}" "${DATA_DIR}/remaining_f4_to_f5_${TIMESTAMP}.log" 2>/dev/null || true
+    else
+      log "ERROR: Step 1 failed (exit code ${JAVA_EXIT}). Check ${F5_LOG}" >&2
+    fi
+    exit 1
+  fi
+fi
+
+# ── Step 2: F5 → F6 ──────────────────────────────────────────────────────────
+
+F6_LOG="${DATA_DIR}/upgrade_6_${TIMESTAMP}.log"
+F6_DONE_MARKER="${DATA_DIR}/.f5_to_f6_complete"
+
+if [[ -f "${F6_DONE_MARKER}" ]]; then
+  log "Step 2 (F5→F6) already completed — skipping."
+else
+  RESUME_ARGS=()
+  REMAINING=$(find_remaining "f5_to_f6")
+  if [[ -n "${REMAINING}" ]]; then
+    log "Step 2: Resuming from: ${REMAINING}"
+    RESUME_ARGS=(--resource-info-file "${REMAINING}")
+  else
+    log "Step 2: Migrating Fedora 5 → Fedora 6..."
+  fi
+
+  run_java "${F6_LOG}" \
+    --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
+    -jar /opt/fcrepo-upgrade-utils.jar \
+    --input-dir "${F5_DIR}" \
+    --output-dir "${F6_DIR}" \
+    --source-version 5+ \
+    --target-version 6+ \
+    --base-uri "${BASE_URI}" \
+    "${RESUME_ARGS[@]}"
+  JAVA_EXIT=$?
+
+  if [[ "${JAVA_EXIT}" -eq 0 ]] && output_has_content "${F6_DIR}"; then
+    log "Step 2 (F5→F6) completed successfully."
+    touch "${F6_DONE_MARKER}"
+  else
+    REMAINING_NEW=$(find_remaining "")
+    if [[ -n "${REMAINING_NEW}" ]]; then
+      log "ERROR: Step 2 did not finish. Resume file: ${REMAINING_NEW}" >&2
+      mv "${REMAINING_NEW}" "${DATA_DIR}/remaining_f5_to_f6_${TIMESTAMP}.log" 2>/dev/null || true
+    else
+      log "ERROR: Step 2 failed (exit code ${JAVA_EXIT}). Check ${F6_LOG}" >&2
+    fi
+    exit 1
+  fi
+fi
+
+log "Migration complete. Fedora 6 OCFL data is in: ${F6_DIR}"
+log "Next step: sync ${F6_DIR}/data/ocfl-root to your Fedora 6 storage."

--- a/fedora/fcrepo4-export.sh
+++ b/fedora/fcrepo4-export.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Export all content from a Fedora 4 instance.
+#
+# Environment variables:
+#   FEDORA_URL       Fedora REST API base URL  (default: http://fedora:8080/fedora/rest)
+#   FEDORA_USER      Fedora admin username     (default: fedoraAdmin)
+#   FEDORA_PASSWORD  Fedora admin password     (default: fedoraAdmin)
+#   EXPORT_DIR       Where to write the export (default: /data/fcrepo4_export)
+
+set -euo pipefail
+
+FEDORA_URL="${FEDORA_URL:-http://fedora:8080/fedora/rest}"
+FEDORA_USER="${FEDORA_USER:-fedoraAdmin}"
+FEDORA_PASSWORD="${FEDORA_PASSWORD:-fedoraAdmin}"
+EXPORT_DIR="${EXPORT_DIR:-/data/fcrepo4_export}"
+DATA_DIR="${DATA_DIR:-/data}"
+
+TIMESTAMP=$(date +%Y%m%dT%H%M%S)
+LOG_FILE="${DATA_DIR}/export_${TIMESTAMP}.log"
+
+mkdir -p "${EXPORT_DIR}"
+
+echo "[$(date -Iseconds)] Starting Fedora 4 export"
+echo "  FEDORA_URL : ${FEDORA_URL}"
+echo "  EXPORT_DIR : ${EXPORT_DIR}"
+echo "  LOG_FILE   : ${LOG_FILE}"
+
+# ── Resume support ──────────────────────────────────────────────────────────
+# Per upstream docs, resuming requires --repositoryRoot + --resourcesFile
+# instead of --resource. The two flags are mutually exclusive.
+RESUME_ARGS=()
+REMAINING=$(ls -t "${DATA_DIR}"/remaining_*.log 2>/dev/null | head -1 || true)
+if [[ -n "${REMAINING}" ]]; then
+  echo "[$(date -Iseconds)] Resuming from: ${REMAINING}"
+  RESUME_ARGS=(--repositoryRoot "${FEDORA_URL}" --resourcesFile "${REMAINING}")
+else
+  RESUME_ARGS=(--resource "${FEDORA_URL}")
+fi
+
+# ── Run export ───────────────────────────────────────────────────────────────
+java -jar /opt/fcrepo-import-export.jar -b \
+  --dir "${EXPORT_DIR}" \
+  --user "${FEDORA_USER}:${FEDORA_PASSWORD}" \
+  --mode export \
+  --binaries \
+  --membership \
+  --auditLog \
+  "${RESUME_ARGS[@]}" \
+  2>&1 | tee "${LOG_FILE}"
+
+# ── Verify completion ────────────────────────────────────────────────────────
+if grep -q "(Exporter) Export complete" "${LOG_FILE}"; then
+  echo "[$(date -Iseconds)] Export completed successfully. Output: ${EXPORT_DIR}"
+else
+  REMAINING_NEW=$(ls -t "${DATA_DIR}"/remaining_*.log 2>/dev/null | head -1 || true)
+  if [[ -n "${REMAINING_NEW}" ]]; then
+    echo "[$(date -Iseconds)] ERROR: Export did not finish. Resume file: ${REMAINING_NEW}" >&2
+    echo "  Re-run the container with the same /data volume to resume." >&2
+  else
+    echo "[$(date -Iseconds)] ERROR: Export may have failed. Check ${LOG_FILE}" >&2
+  fi
+  exit 1
+fi


### PR DESCRIPTION
- fedora/Dockerfile.fcrepo4-export: Image based on eclipse-temurin:21-jre-jammy that exports all content from a running Fedora 4 instance using fcrepo-import-export-1.2.0.jar. Supports automatic resume via remaining_*.log detection.
- fedora/fcrepo4-export.sh: Entrypoint script for the export image. On resume, switches from --resource to --repositoryRoot + --resourcesFile as required by the import/export tool.
- fedora/Dockerfile.fcrepo-migrate-4-to-6: Image based on eclipse-temurin:21-jre-jammy that migrates a Fedora 4 export to Fedora 6 OCFL format using fcrepo-upgrade-utils-6.3.0-AVALON.jar (two-step: F4→F5→F6).
- fedora/fcrepo-migrate-4-to-6.sh: Entrypoint script for the migration image. Uses done-marker files to skip already-completed steps on re-run, and detects/resumes partial migrations via remaining_*.log files.

https://umd-dit.atlassian.net/browse/LIBAVALON-538